### PR TITLE
Fixes missing support of helper parameters

### DIFF
--- a/lib/extractors/hbs.js
+++ b/lib/extractors/hbs.js
@@ -28,6 +28,7 @@ function handle_statements(statements, opts, nodes) {
     statements.forEach(function(statement) {
         if (statement.type === 'MustacheStatement' || statement.type === 'SubExpression') {
             handle_mustache(statement, opts, nodes);
+            handle_partial(statement, opts, nodes);
 
         } else if (statement.type === 'BlockStatement') {
             handle_statements(statement.program.body, opts, nodes);

--- a/test/extractors/hbs.test.js
+++ b/test/extractors/hbs.test.js
@@ -6,6 +6,7 @@ describe("jspot.extractors:hbs", function() {
     var extractor = jspot.extractors.get('hbs');
 
     describe("call to jspot gettext", function() {
+
         it("should forward gettext calls", function() {
             assert.deepEqual(
                 extractor({
@@ -56,6 +57,7 @@ describe("jspot.extractors:hbs", function() {
 
 
     describe("no results", function() {
+
         it("should have no result if no gettext call", function() {
             assert.equal(
                 extractor({
@@ -79,6 +81,7 @@ describe("jspot.extractors:hbs", function() {
 
 
     describe("hbs extractor options", function() {
+
         it("should allow a different keyword to be used", function() {
             assert.deepEqual(
                 extractor({
@@ -320,8 +323,8 @@ describe("jspot.extractors:hbs", function() {
 
     });
 
-
     describe("handlebars mustaches", function() {
+
         it("should work inside a safe string statement", function() {
             assert.deepEqual(
                 extractor({
@@ -638,6 +641,173 @@ describe("jspot.extractors:hbs", function() {
                 }]
             );
         });
+
+    });
+
+    describe("handlebars helpers", function() {
+
+        it("should work for helper hash parameters", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{input placeholder=(gettext 'type here...') }}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                [{
+                    key: 'type here...',
+                    plural: null,
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 2,
+                    filename: 'foo.js'
+                }]
+            );
+        });
+
+
+        it("should work for helper hash parameters with plural", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{input placeholder=(gettext_ngettext 'type here...' 'type here a lot...' 0 ) }}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                [{
+                    key: 'type here...',
+                    plural: 'type here a lot...',
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 2,
+                    filename: 'foo.js'
+                }]
+            );
+        });
+
+        it("should work for partial with multiple hash parameters", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{input placeholder=(gettext 'type here...' ) title=(gettext 'just an input' ) }}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                [{
+                    key: 'type here...',
+                    plural: null,
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 2,
+                    filename: 'foo.js'
+                }, {
+                    key: 'just an input',
+                    plural: null,
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 2,
+                    filename: 'foo.js'
+                }]
+            );
+        });
+
+        it("should work for partial without hash parameters", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{input }}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                []
+            );
+        });
+
+        it("should work for partial with single parameters", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{input bar }}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                []
+            );
+        });
+
+        it("should work for partial with single & hash parameters", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{input bar placeholder=(gettext 'type here...') }}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                [{
+                    key: 'type here...',
+                    plural: null,
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 2,
+                    filename: 'foo.js'
+                }]
+            );
+        });
+
+        it("should work for partial hash parameters and some others statement", function() {
+            assert.deepEqual(
+                extractor({
+                    filename: 'foo.js',
+                    source: [
+                        "<span>",
+                        "{{#if bar }}",
+                        "{{input placeholder=(gettext 'type here...') }}",
+                        "{{else}}",
+                        "<span>{{gettext 'you cannot see me' }}</span>",
+                        "{{/if}}",
+                        "</span>"
+                    ].join('\n')
+                }),
+                [{
+                    key: 'type here...',
+                    plural: null,
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 3,
+                    filename: 'foo.js'
+                }, {
+                    key: 'you cannot see me',
+                    plural: null,
+                    domain: 'messages',
+                    context: '',
+                    category: null,
+                    line: 5,
+                    filename: 'foo.js'
+                }]
+            );
+        });
+
+    });
+
+    describe("handlebars partials", function() {
 
         it("should work for partial hash parameters", function() {
             assert.deepEqual(


### PR DESCRIPTION
The handlebars extractor did not support use of gettext inside helper parameters